### PR TITLE
fix if else lint and scopelint

### DIFF
--- a/crc16/crc16_test.go
+++ b/crc16/crc16_test.go
@@ -45,6 +45,7 @@ func TestChecksumCCITTFalse(t *testing.T) {
 		{"How can you write a big system without C++?  -Paul Glick", 0xCEEA},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run("", func(t *testing.T) {
 			if crc := crc16.ChecksumCCITTFalse([]byte(tt.in)); crc != tt.out {
 				t.Errorf("ChecksumCCITTFalse(%s) = 0x%x want 0x%x", tt.in, crc, tt.out)
@@ -78,7 +79,7 @@ func TestDigest_BlockSize(t *testing.T) {
 
 func TestDigest_Reset(t *testing.T) {
 
-	defer func(){
+	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("unexpected panic, catch: %+v", r)
 		}
@@ -135,6 +136,7 @@ func TestDigest_Sum16(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run("", func(t *testing.T) {
 			h := crc16.NewCCITTFalse()
 			_, err := h.Write([]byte(tt.in))

--- a/mpm/emv_test.go
+++ b/mpm/emv_test.go
@@ -141,6 +141,7 @@ func TestDecoder_Decode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			dst, err := mpm.Decode(tt.args.buf)
 
@@ -247,6 +248,7 @@ func TestEncoder_Encode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			buf, err := mpm.Encode(tt.args.in)
 

--- a/mpm/jpqr/id_test.go
+++ b/mpm/jpqr/id_test.go
@@ -99,6 +99,7 @@ func TestParseID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := jpqr.ParseID(tt.args.c)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -136,6 +137,7 @@ func TestID_String(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			i := &jpqr.ID{
 				Prefix: tt.fields.Prefix,

--- a/mpm/jpqr/jpqr_test.go
+++ b/mpm/jpqr/jpqr_test.go
@@ -67,6 +67,7 @@ func TestDecode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := jpqr.Decode(tt.args.payload)
 			if (err != nil) != tt.wantErr {
@@ -169,6 +170,7 @@ func TestEncode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := jpqr.Encode(tt.args.code)
 			if (err != nil) != tt.wantErr {

--- a/mpm/types.go
+++ b/mpm/types.go
@@ -15,6 +15,7 @@ type NullMerchantInformation struct {
 	Valid              bool
 }
 
+// Tokenize turns NullMerchantInformation into a string
 func (m *NullMerchantInformation) Tokenize() (string, error) {
 	if m == nil {
 		return "", nil
@@ -47,6 +48,7 @@ const (
 	PointOfInitiationMethodDynamic                         = "12"
 )
 
+// Tokenize turns PointOfInitiationMethod into a string
 func (p *PointOfInitiationMethod) Tokenize() (string, error) {
 	if p == nil {
 		return "", nil
@@ -72,6 +74,7 @@ type NullString struct {
 	Valid  bool
 }
 
+// Tokenize turns NullString into a string
 func (n *NullString) Tokenize() (string, error) {
 	if n == nil || !n.Valid {
 		return "", nil
@@ -97,6 +100,7 @@ const (
 	TipOrConvenienceIndicatorPercentage                           = "03"
 )
 
+// Tokenize turns TipOrConvenienceIndicator into a string
 func (t *TipOrConvenienceIndicator) Tokenize() (string, error) {
 	if t == nil {
 		return "", nil

--- a/tlv/encode.go
+++ b/tlv/encode.go
@@ -70,9 +70,8 @@ func (e *Encoder) Encode(src interface{}) error {
 			} else {
 				if e, ok := err.(error); ok {
 					return e
-				} else {
-					return errors.New("unexpected value returned")
 				}
+				return errors.New("unexpected value returned")
 			}
 		}
 

--- a/tlv/scan.go
+++ b/tlv/scan.go
@@ -45,7 +45,7 @@ func scan(v reflect.Value, m map[string]int, token []rune, tagLength, lenLength 
 		}
 
 		if isScannable(f.Type()) {
-			if !f.CanAddr(){
+			if !f.CanAddr() {
 				return fmt.Errorf("field must have addressability")
 			}
 
@@ -59,12 +59,11 @@ func scan(v reflect.Value, m map[string]int, token []rune, tagLength, lenLength 
 			err := res[0].Interface()
 			if err == nil {
 				return nil
-			} else {
-				if e, ok := err.(error); ok {
-					return e
-				}
-				return fmt.Errorf("unexpected value returned id: %s", string(tag))
 			}
+			if e, ok := err.(error); ok {
+				return e
+			}
+			return fmt.Errorf("unexpected value returned id: %s", string(tag))
 		}
 
 		switch f.Kind() {


### PR DESCRIPTION
* golint (if else)

```
if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
```

* [scopelint](https://github.com/kyoh86/scopelint)

```
Using the variable on range scope "tt" in function literal
```