### PR TITLE
tlv: keep the order of struct fields

### DIFF
--- a/mpm/emv_test.go
+++ b/mpm/emv_test.go
@@ -1,7 +1,6 @@
 package mpm_test
 
 import (
-	"io"
 	"reflect"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 	"go.mercari.io/go-emv-code/tlv"
 )
 
-var emvSamplePayload = []byte("00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115802CN5914BEST TRANSPORT6007BEIJING64200002ZH0104最佳运输0202北京540523.7253031565502016233030412340603***0708A60086670902ME91320016A0112233449988770708123456786304A13A")
+var emvSamplePayload = []byte("00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115303156540523.725502015802CN5914BEST TRANSPORT6007BEIJING6233030412340603***0708A60086670902ME64200002ZH0104最佳运输0202北京6304CDE7")
 
 func TestDecoder_Decode(t *testing.T) {
 	type invalidFormat interface {
@@ -170,15 +169,11 @@ func BenchmarkDecode(b *testing.B) {
 }
 
 func TestEncoder_Encode(t *testing.T) {
-	type fields struct {
-		r *io.Writer
-	}
 	type args struct {
 		in *mpm.Code
 	}
 	tests := []struct {
 		name            string
-		fields          fields
 		args            args
 		want            []byte
 		wantErr         bool
@@ -240,7 +235,7 @@ func TestEncoder_Encode(t *testing.T) {
 					AdditionalDataFieldTemplate: "030412340603***0708A60086670902ME",
 				},
 			},
-			want: []byte("00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115802CN5914BEST TRANSPORT6007BEIJING540523.7253031565502016233030412340603***0708A60086670902ME91320016A0112233449988770708123456786304FF8B"),
+			want: []byte("00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115303156540523.725502015802CN5914BEST TRANSPORT6007BEIJING6233030412340603***0708A60086670902ME6304EBA6"),
 		},
 		{
 			name:    "err: cannot pass nil pointer",
@@ -261,18 +256,8 @@ func TestEncoder_Encode(t *testing.T) {
 			}
 
 			if tt.want != nil {
-				inDst, err := mpm.Decode(buf)
-				if err != nil {
-					t.Errorf("unexpected error = %v", err)
-				}
-
-				wantDst, err := mpm.Decode(tt.want)
-				if err != nil {
-					t.Errorf("unexpected error = %v", err)
-				}
-
-				if !reflect.DeepEqual(inDst, wantDst) {
-					t.Errorf("Encoder.Encode() = %v, want %v", inDst, wantDst)
+				if !reflect.DeepEqual(buf, tt.want) {
+					t.Errorf("Encoder.Encode() = %v, want %v", buf, tt.want)
 				}
 			}
 		})

--- a/tlv/encode.go
+++ b/tlv/encode.go
@@ -41,13 +41,16 @@ func (e *Encoder) Encode(src interface{}) error {
 		return errors.New("nil pointer passed")
 	}
 
-	indexes := tagIndexMap(v, e.tagName)
+	tags := tags(v, e.tagName)
 
 	v = reflect.Indirect(v)
-	for id, index := range indexes {
-		if _, ok := e.ignoreTags[id]; ok {
+	for _, tag := range tags {
+		if _, ok := e.ignoreTags[tag.id]; ok {
 			continue
 		}
+
+		id := tag.id
+		index := tag.index
 
 		f := v.Field(index)
 		if isTokenizable(f.Type()) {

--- a/tlv/scan.go
+++ b/tlv/scan.go
@@ -122,16 +122,16 @@ type tag struct {
 func tags(v reflect.Value, tagName string) []tag {
 	v = reflect.Indirect(v)
 	t := deref(v.Type())
-	m := make([]tag, 0, t.NumField())
+	s := make([]tag, 0, t.NumField())
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if emvTag, ok := f.Tag.Lookup(tagName); ok {
-			m = append(m, tag{emvTag, i})
+			s = append(s, tag{emvTag, i})
 		}
 	}
 
-	return m
+	return s
 }
 
 func tagIndexMap(v reflect.Value, tagName string) map[string]int {

--- a/tlv/scan.go
+++ b/tlv/scan.go
@@ -114,6 +114,26 @@ func deref(t reflect.Type) reflect.Type {
 	return t
 }
 
+type tag struct {
+	id    string
+	index int
+}
+
+func tags(v reflect.Value, tagName string) []tag {
+	v = reflect.Indirect(v)
+	t := deref(v.Type())
+	m := make([]tag, 0, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if emvTag, ok := f.Tag.Lookup(tagName); ok {
+			m = append(m, tag{emvTag, i})
+		}
+	}
+
+	return m
+}
+
 func tagIndexMap(v reflect.Value, tagName string) map[string]int {
 	v = reflect.Indirect(v)
 	t := deref(v.Type())


### PR DESCRIPTION
<!--
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/
-->

## WHAT
I modified `Encode` in `tlv` package to keep the order of the struct's fields

## WHY
For reproducible encoding.