### PR TITLE
mpm: add two mandatory field validators

### DIFF
--- a/mpm/emv.go
+++ b/mpm/emv.go
@@ -97,7 +97,12 @@ func Decode(payload []byte, vfs ...ValidatorFunc) (*Code, error) {
 		return nil, err
 	}
 
-	vfs = append(vfs, validateMerchantInformation)
+	vfs = append(
+		vfs,
+		validateMerchantName,
+		validateMerchantCity,
+		validateMerchantInformation,
+	)
 	for _, f := range vfs {
 		if err := f(&c); err != nil {
 			return nil, err
@@ -154,6 +159,20 @@ func Encode(c *Code, vfs ...ValidatorFunc) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func validateMerchantName(c *Code) error {
+	if c.MerchantName == "" || 25 < utf8.RuneCountInString(c.MerchantName) {
+		return NewInvalidFormat("mpm: length of MerchantName should be between 1 and 25")
+	}
+	return nil
+}
+
+func validateMerchantCity(c *Code) error {
+	if c.MerchantCity == "" || 15 < utf8.RuneCountInString(c.MerchantCity) {
+		return NewInvalidFormat("mpm: length of MerchantCity should be between 1 and 15")
+	}
+	return nil
 }
 
 func validateMerchantInformation(c *Code) error {


### PR DESCRIPTION
<!--
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/
-->

## WHAT
Add validators for MerchantName and MerchantCity.

## WHY
According to [EMV® QR Code Specification for Payment Systems: Merchant-Presented Mode](https://www.emvco.com/emv-technologies/qrcodes/), The length of MerchantName and MerchantCity should be what I added.