### PR TITLE
Fix missing assign in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ REVIEWDOG_ARG ?= -diff="git diff master"
 
 LINT_TOOLS=$(shell cat tools/tools.go | egrep '^\s_ '  | awk '{ print $$2 }')
 
+GOPATH := $(shell go env GOPATH)
+GOBIN ?= $(GOPATH)/bin
+
 .PHONY: all
 all: test
 


### PR DESCRIPTION
<!--
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/
-->

## WHAT

- Fix missing assign in Makefile

## WHY

We use variable `$(GOBIN)` but initialization is missing.
https://github.com/mercari/go-emv-code/blob/b7d3f8f53de071d4b7acc4861750afebbf46ce57/Makefile#L21